### PR TITLE
fix(agnositc-lite): no_std compatability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/al8n/agnostic"
 keywords = ["async", "runtime", "agnostic", "sansio", "sans"]
 
 [workspace.dependencies]
-atomic-time = "0.1"
+atomic-time = {version = "0.1", default-features = false}
 async-io = "2"
 
 futures-util = { version = "0.3", default-features = false }

--- a/agnostic-lite/Cargo.toml
+++ b/agnostic-lite/Cargo.toml
@@ -57,7 +57,7 @@ wasm = { workspace = true, features = ["wasm-bindgen"], optional = true }
 wasm = { workspace = true, optional = true }
 
 [dependencies]
-atomic-time = { workspace = true, optional = true }
+atomic-time = { workspace = true, optional = true, default-features = false }
 futures-util = { workspace = true, default-features = false }
 pin-project-lite.workspace = true
 pin-project = "1"


### PR DESCRIPTION
The default features of `atomic-time` require `std`. As-is `agnostic-lite` does not compile in a no_std environment due to this. Everything seems to compile fine with default features disabled 

https://github.com/al8n/atomic-time/blob/fb1a57521d5f18c86b51baa3eea8d48201199d71/Cargo.toml#L27